### PR TITLE
Fix: Twitter links on About Page

### DIFF
--- a/grails-app/views/about/index.gsp
+++ b/grails-app/views/about/index.gsp
@@ -14,12 +14,12 @@
     <p>This portal wouldn't be running if it weren't due to the efforts of the following people involved in its design, development and deployment
     <ul>
         <li>Ixchel Ruiz (<a
-            href="https://twitter.com/#!/ixchelruiz">@ixchelruiz</a>)</li>
-        <li>Mac (<a href="https://twitter.com/#!/wmacgyver">@wmacgyver</a>)</li>
+            href="https://twitter.com/ixchelruiz">@ixchelruiz</a>)</li>
+        <li>Mac (<a href="https://twitter.com/wmacgyver">@wmacgyver</a>)</li>
         <li>Alexander Klein (<a
-            href="https://twitter.com/#!/saschaklein">@saschaklein</a>)</li>
+            href="https://twitter.com/saschaklein">@saschaklein</a>)</li>
         <li>Andres Almiray (<a
-            href="https://twitter.com/#!/aalmiray">@aalmiray</a>)</li>
+            href="https://twitter.com/aalmiray">@aalmiray</a>)</li>
     </ul></p>
 
     <h2>Get it!</h2>


### PR DESCRIPTION
Twitter has changed paths to use profiles from (twitter.com/#!/username) to (twitter.com/username)
